### PR TITLE
Increase max rules per file to 150k

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://github.com/bnema/ublock-webkit-filters/releases/latest/download/manifest
 
 | File | Description |
 |------|-------------|
-| `combined-part1.json`, `combined-part2.json`, ... | All lists merged and deduplicated (split at 50k rules) |
+| `combined-part1.json`, `combined-part2.json`, ... | All lists merged and deduplicated (split at 150k rules) |
 | `easylist.json` | EasyList - ad blocking |
 | `easyprivacy.json` | EasyPrivacy - tracker blocking |
 | `ublock-filters.json` | uBlock Origin optimizations |
@@ -98,7 +98,7 @@ timeout = "30s"
 retries = 3
 
 [output]
-max_rules_per_file = 50000
+max_rules_per_file = 150000
 generate_combined = true
 generate_manifest = true
 

--- a/cmd/ublock-webkit-filters/main.go
+++ b/cmd/ublock-webkit-filters/main.go
@@ -80,7 +80,7 @@ func initConfig() {
 	// Set defaults
 	viper.SetDefault("http.timeout", "30s")
 	viper.SetDefault("http.retries", 3)
-	viper.SetDefault("output.max_rules_per_file", 50000)
+	viper.SetDefault("output.max_rules_per_file", 150000)
 	viper.SetDefault("output.generate_combined", true)
 	viper.SetDefault("output.generate_manifest", true)
 
@@ -279,7 +279,7 @@ retries = 3
 
 # Output settings
 [output]
-max_rules_per_file = 50000
+max_rules_per_file = 150000
 generate_combined = true
 generate_manifest = true
 

--- a/configs/filter_lists.toml
+++ b/configs/filter_lists.toml
@@ -7,7 +7,7 @@ retries = 3
 
 # Output settings
 [output]
-max_rules_per_file = 50000
+max_rules_per_file = 150000
 generate_combined = true
 generate_manifest = true
 

--- a/internal/converter/splitter.go
+++ b/internal/converter/splitter.go
@@ -8,9 +8,9 @@ import (
 )
 
 // MaxRulesPerFile is Safari/WebKit's limit per content blocker
-const MaxRulesPerFile = 50000
+const MaxRulesPerFile = 150000
 
-// Splitter splits rules into chunks respecting the 50k limit
+// Splitter splits rules into chunks respecting the 150k limit
 type Splitter struct {
 	maxRules int
 }

--- a/internal/converter/webkit_constraints.go
+++ b/internal/converter/webkit_constraints.go
@@ -42,7 +42,7 @@ package converter
 // - Complex patterns significantly increase compile time
 // - Use url-filter-is-case-sensitive when possible
 // - Avoid patterns like foo.*bar (quantifier in middle)
-// - Maximum 50,000 rules per content blocker
+// - Maximum 150,000 rules per content blocker
 
 import (
 	"strings"


### PR DESCRIPTION
50,000 rules was the original limit, but it was increased long ago in https://commits.webkit.org/232238@main.