### PR TITLE
fix: avoid malformed blockers from Peter Lowe hosts input

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ This project prefers safety over over-blocking: if a uBO filter cannot be repres
 - [EasyList](https://easylist.to/) - Ad blocking
 - [EasyPrivacy](https://easylist.to/) - Tracker blocking
 - [uBlock Origin filters](https://github.com/uBlockOrigin/uAssets) - Optimizations
-- [Peter Lowe's Ad server list](https://pgl.yoyo.org/adservers/)
+- [Peter Lowe's Ad server list](https://pgl.yoyo.org/adservers/) - Adblock Plus format
 
 ## License
 

--- a/cmd/ublock-webkit-filters/main.go
+++ b/cmd/ublock-webkit-filters/main.go
@@ -323,7 +323,7 @@ enabled = true
 
 [[lists]]
 name = "peter-lowe"
-url = "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext"
+url = "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&mimetype=plaintext"
 enabled = true
 `
 

--- a/configs/filter_lists.toml
+++ b/configs/filter_lists.toml
@@ -51,7 +51,7 @@ enabled = true
 
 [[lists]]
 name = "peter-lowe"
-url = "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext"
+url = "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&mimetype=plaintext"
 enabled = true
 
 # Optional lists (disabled by default)

--- a/internal/converter/integration_test.go
+++ b/internal/converter/integration_test.go
@@ -220,6 +220,33 @@ func TestNoCatchAllBlockRulesInOutput(t *testing.T) {
 	assert.True(t, len(rules) >= 2, "Safe filters should produce rules, got %d", len(rules))
 }
 
+func TestHashCommentsAndHostsEntriesDoNotGenerateBlockingRules(t *testing.T) {
+	input := `# Blocklist header
+#
+127.0.0.1 101com.com
+0.0.0.0 tracker.example
+||valid.example^
+`
+
+	p := parser.New()
+	filters, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, filters, 1, "only the valid ABP rule should survive parsing")
+	assert.Equal(t, "||valid.example^", filters[0].Pattern)
+	assert.Equal(t, 2, p.Stats().Comments)
+	assert.Equal(t, 2, p.Stats().SkipReasons[parser.SkipHostsEntry])
+
+	c := New()
+	rules := Deduplicate(c.Convert(filters))
+	require.NotEmpty(t, rules)
+
+	for _, r := range rules {
+		assert.NotEqual(t, "#", r.Trigger.URLFilter)
+		assert.NotContains(t, r.Trigger.URLFilter, "127\\.0\\.0\\.1")
+		assert.NotContains(t, r.Trigger.URLFilter, "0\\.0\\.0\\.0")
+	}
+}
+
 func TestUnsupportedWildcardModifiersDoNotBlockRealSites(t *testing.T) {
 	// Before the parser fix, the first two lines below degraded into global
 	// ".*" block rules and would have blocked any top-level document, including

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bufio"
 	"io"
+	"net"
 	"strings"
 
 	"github.com/bnema/ublock-webkit-filters/internal/models"
@@ -51,6 +52,7 @@ const (
 	SkipUnsupportedOpt    = "unsupported-option (redirect, csp, etc)"
 	SkipInvalidRegex      = "invalid-regex"
 	SkipCosmeticException = "cosmetic-exception (#@#)"
+	SkipHostsEntry        = "hosts-entry-unsupported"
 )
 
 // New creates a new parser
@@ -111,8 +113,15 @@ func (p *Parser) Parse(r io.Reader) ([]models.Filter, error) {
 // parseLine parses a single filter line
 func (p *Parser) parseLine(line string) models.Filter {
 	// Comments
-	if strings.HasPrefix(line, "!") || strings.HasPrefix(line, "[") {
+	if isCommentLine(line) {
 		return models.Filter{Type: models.FilterTypeComment, Raw: line}
+	}
+
+	// Hosts-file entries are not ABP/uBO syntax. If they slip into the
+	// pipeline, skipping them is safer than converting the literal IP + host
+	// text into an unintended URL regex.
+	if looksLikeHostsEntry(line) {
+		return p.skip(SkipHostsEntry)
 	}
 
 	// Scriptlet injection - unsupported
@@ -147,6 +156,40 @@ func (p *Parser) parseLine(line string) models.Filter {
 
 	// Network filters
 	return p.parseNetwork(line, false)
+}
+
+func isCommentLine(line string) bool {
+	if strings.HasPrefix(line, "!") || strings.HasPrefix(line, "[") {
+		return true
+	}
+
+	// Hosts-style lists commonly use leading "#" comments. Keep cosmetic
+	// syntaxes available by excluding "##" and "#@#".
+	return strings.HasPrefix(line, "#") &&
+		!strings.HasPrefix(line, "##") &&
+		!strings.HasPrefix(line, "#@#")
+}
+
+func looksLikeHostsEntry(line string) bool {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return false
+	}
+
+	if net.ParseIP(fields[0]) == nil {
+		return false
+	}
+
+	for _, field := range fields[1:] {
+		if strings.HasPrefix(field, "#") {
+			break
+		}
+		if field != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 // containsProcedural checks for procedural cosmetic filter syntax

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -147,3 +147,30 @@ func TestLatestWebKitResourceTypesAreUsed(t *testing.T) {
 	assert.Equal(t, []string{models.ResourceWebSocket}, filters[3].Options.ResourceTypes)
 	assert.Equal(t, []string{models.ResourceOther}, filters[4].Options.ResourceTypes)
 }
+
+func TestHashCommentsAreSkippedWithoutBreakingCosmeticSyntax(t *testing.T) {
+	p := New()
+	filters, err := p.Parse(strings.NewReader(
+		`#
+# plain comment
+##.ad-slot
+#@#.ad-slot`,
+	))
+	assert.NoError(t, err)
+	assert.Len(t, filters, 2, "cosmetic syntaxes must still parse while # comments are skipped")
+	assert.Equal(t, models.FilterTypeCosmetic, filters[0].Type)
+	assert.Equal(t, models.FilterTypeCosmeticException, filters[1].Type)
+	assert.Equal(t, 2, p.Stats().Comments)
+}
+
+func TestHostsEntriesAreSkipped(t *testing.T) {
+	p := New()
+	filters, err := p.Parse(strings.NewReader(
+		`127.0.0.1 101com.com
+0.0.0.0 tracker.example # inline comment`,
+	))
+	assert.NoError(t, err)
+	assert.Empty(t, filters, "hosts-file entries should be skipped, not converted literally")
+	assert.Equal(t, 2, p.Stats().Unsupported)
+	assert.Equal(t, 2, p.Stats().SkipReasons[SkipHostsEntry])
+}


### PR DESCRIPTION
## Summary
- switch Peter Lowe to its Adblock Plus formatted feed instead of the hosts-form variant
- treat leading `#` lines as comments without breaking cosmetic syntaxes like `##` and `#@#`
- skip hosts-style entries if they still slip into parsing, and add regressions to prevent `url-filter: "#"` or literal host-entry blockers

## Why
The hosts-form Peter Lowe feed was producing malformed block rules such as `url-filter: "#"`, which can block legitimate OAuth callback URLs containing fragments and break flows like Google sign-in for Tailscale.

## Validation
- `go test ./...`
- generated output no longer contains `url-filter: "#"` rules or literal `127.0.0.1 ...` host-entry rules

Closes #8
